### PR TITLE
Implemented SQS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ Installation
 
 `pip install elife_bus_sdk`
 
+AWS Credentials
+---------------
+To use any of the AWS provided services through this library, you will need to provide credentials in a way that is supported [here.](http://boto3.readthedocs.io/en/latest/guide/configuration.html) 
+
+
 Publisher
 ---------
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,16 @@ for msg in message_queue.poll():
     print(msg)
 ```
 
+Check if a queue is polling:
+```python
+message_queue.is_polling()
+```
+
+Stop a queue from polling (normally running in another thread):
+```python
+message_queue.stop_polling()
+```
+
 Receive message(s):
 ```python
 msg = message_queue.dequeue()

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Installation
 Publisher
 ---------
 
+Current supported:
+- [SNS](https://aws.amazon.com/sns/)
+
 Configuration:
 
 ```python
@@ -27,8 +30,78 @@ config = {
     'region': 'us-east-2',
     'subscriber': '00000000000',       
     'name': 'profile',
-    'env': 'prod'
+    'env': 'dev'
 }
 
-publisher = get_publisher(pub_name='test', pub_type='sns', config=config)
+publisher = get_publisher(config=config, pub_type='sns')
+print(publisher.arn)
+>>> 'arn:aws:sns:us-east-2:00000000000:profile--dev'
 ```
+
+Publish:
+
+```python
+from elife_bus_sdk.events import Event
+
+publisher.publish(Event(foo='bar', some='fields'))
+
+```
+
+Queue
+---------
+
+Current supported:
+- [SQS](https://aws.amazon.com/sqs/)
+
+
+Configuration:
+
+```python
+from elife_bus_sdk import get_queue
+
+config = {   
+    'QueueName': 'some_queue',
+}
+
+message_queue = get_queue(config=config, pub_type='sqs')
+```
+
+Poll for messages:
+```python
+for msg in message_queue.poll():
+    print(msg)
+```
+
+Receive message(s):
+```python
+msg = message_queue.dequeue()
+```
+
+Send message:
+```python
+message_queue.enqueue('test message')
+```
+
+Local Testing
+-------------
+To test the `aws` services locally you can setup [goaws](https://github.com/p4tin/goaws) and pass the local `endpoint_url` value to your configuration.
+
+Example:
+
+```python
+from elife_bus_sdk import get_queue
+
+dev_config = {
+    'endpoint_url': 'http://localhost:4100',
+    'QueueName': 'test1',
+}
+
+message_queue = get_queue(config=dev_config, q_type='sqs')
+```
+
+Tests
+-----
+
+You can run the full automated test suite from the base folder with:
+
+`$ ./project_tests.sh`

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Configuration:
 from elife_bus_sdk import get_queue
 
 config = {   
-    'QueueName': 'some_queue',
+    'queue_name': 'some_queue',
 }
 
 message_queue = get_queue(config=config, pub_type='sqs')
@@ -98,7 +98,7 @@ from elife_bus_sdk import get_queue
 
 dev_config = {
     'endpoint_url': 'http://localhost:4100',
-    'QueueName': 'test1',
+    'queue_name': 'test1',
 }
 
 message_queue = get_queue(config=dev_config, q_type='sqs')

--- a/elife_bus_sdk/__init__.py
+++ b/elife_bus_sdk/__init__.py
@@ -1,36 +1,44 @@
-from elife_bus_sdk.publishers import (
-    EventPublisher,
-    get_publisher_types
-)
+from elife_bus_sdk.exceptions import PublisherTypeNotFound, MessageQueueTypeNotFound
+from elife_bus_sdk.publishers import EventPublisher, get_publisher_types
+from elife_bus_sdk.queues import MessageQueue, get_queue_types
 
 
-__version__ = '0.0.3'
+__version__ = '0.0.4'
 
 
-DEFAULT_NAME = 'default_publisher'
-DEFAULT_TYPE = 'sns'
-PUBLISHERS = {}
+DEFAULT_PUB_TYPE = 'sns'
 PUBLISHER_TYPES = get_publisher_types()
 
+DEFAULT_QUEUE_TYPE = 'sqs'
+QUEUE_TYPES = get_queue_types()
 
-def get_publisher(config: dict, pub_name: str = DEFAULT_NAME,
-                  pub_type: str = DEFAULT_TYPE) -> EventPublisher:
-    """
-    Publisher factory function.
 
-    If a publisher already exists with the `pub_name` value
-    then you will be returned that instance, otherwise the publisher
-    will be created and returned.
+def get_publisher(config: dict, pub_type: str = DEFAULT_PUB_TYPE) -> EventPublisher:
+    """Publisher factory function.
 
     :param config: dict
-    :param pub_name: str
     :param pub_type: str
     :return: :class: `EventPublisher`
     """
-    if not PUBLISHERS.get(pub_name, None):
-        if not pub_type:
-            raise AttributeError('`pub_type` is a required argument for uninitialized PUBLISHERS')
+    publisher = PUBLISHER_TYPES.get(pub_type, None)
 
-        PUBLISHERS[pub_name] = PUBLISHER_TYPES[pub_type](**config)
+    if not publisher:
+        raise PublisherTypeNotFound('Publisher type: {} was not found'.format(pub_type))
 
-    return PUBLISHERS[pub_name]
+    return publisher(**config)
+
+
+def get_queue(config: dict, q_type: str = DEFAULT_QUEUE_TYPE) -> MessageQueue:
+    """MessageQueue factory function.
+
+    :param config: dict
+    :param q_type: str
+    :return: :class: `MessageQueue`
+    """
+
+    queue = QUEUE_TYPES.get(q_type, None)
+
+    if not queue:
+        raise MessageQueueTypeNotFound('MessageQueue type: {} was not found'.format(q_type))
+
+    return queue(**config)

--- a/elife_bus_sdk/exceptions.py
+++ b/elife_bus_sdk/exceptions.py
@@ -1,0 +1,8 @@
+
+
+class PublisherTypeNotFound(Exception):
+    pass
+
+
+class MessageQueueTypeNotFound(Exception):
+    pass

--- a/elife_bus_sdk/publishers/__init__.py
+++ b/elife_bus_sdk/publishers/__init__.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 from elife_bus_sdk.publishers.event_publisher import EventPublisher
 from elife_bus_sdk.publishers import sns_publisher
 from elife_bus_sdk.publishers.sns_publisher import SNSPublisher
@@ -9,7 +11,7 @@ PUBLISHERS = [
 ]
 
 
-def get_publisher_types() -> dict:
+def get_publisher_types() -> Dict[str, EventPublisher]:
     return {pub.name: pub for pub in PUBLISHERS}
 
 

--- a/elife_bus_sdk/publishers/sns_publisher.py
+++ b/elife_bus_sdk/publishers/sns_publisher.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 try:
     import boto3
 except ImportError:  # pragma: no cover
@@ -43,7 +45,7 @@ class SNSPublisher(EventPublisher):
                                                                         name=name,
                                                                         env=env)
 
-    def publish(self, event: Event) -> dict:
+    def publish(self, event: Event) -> Dict:
         """
         Publishes a JSON representation of `Event` object to the target AWS SNS Topic.
 

--- a/elife_bus_sdk/publishers/sns_publisher.py
+++ b/elife_bus_sdk/publishers/sns_publisher.py
@@ -1,10 +1,6 @@
 from typing import Dict
 
-try:
-    import boto3
-except ImportError:  # pragma: no cover
-    # boto3 not yet available, may happen in initial install of elife_bus_sdk package
-    pass
+import boto3
 
 from elife_bus_sdk.events import Event
 from elife_bus_sdk.publishers.event_publisher import EventPublisher

--- a/elife_bus_sdk/queues/__init__.py
+++ b/elife_bus_sdk/queues/__init__.py
@@ -1,0 +1,21 @@
+from typing import Dict
+
+from elife_bus_sdk.queues.sqs_queue import SQSMessageQueue
+from elife_bus_sdk.queues.message_queue import MessageQueue
+
+
+# list of queue classes you want to make available
+QUEUES = (
+    SQSMessageQueue,
+)
+
+
+def get_queue_types() -> Dict[str, MessageQueue]:
+    return {q.name: q for q in QUEUES}
+
+
+__all__ = [
+    'get_queue_types',
+    'MessageQueue',
+    'SQSMessageQueue',
+]

--- a/elife_bus_sdk/queues/message_queue.py
+++ b/elife_bus_sdk/queues/message_queue.py
@@ -19,7 +19,7 @@ class MessageQueue(ABC):
         raise NotImplementedError  # pragma: no cover
 
     @abstractmethod
-    def poll(self, parse_msg: bool) -> Generator[Dict, None, None]:
+    def poll(self) -> Generator[Dict, None, None]:
         raise NotImplementedError  # pragma: no cover
 
     @property

--- a/elife_bus_sdk/queues/message_queue.py
+++ b/elife_bus_sdk/queues/message_queue.py
@@ -1,0 +1,28 @@
+from abc import ABC, abstractmethod
+from typing import Any, Dict, Generator
+
+
+class MessageQueue(ABC):
+
+    @abstractmethod
+    def dequeue(self) -> Any:
+        raise NotImplementedError  # pragma: no cover
+
+    @abstractmethod
+    def enqueue(self, message: Dict) -> Any:
+        raise NotImplementedError  # pragma: no cover
+
+    @property
+    @abstractmethod
+    # pylint:disable=duplicate-code
+    def name(self) -> str:
+        raise NotImplementedError  # pragma: no cover
+
+    @abstractmethod
+    def poll(self, parse_msg: bool) -> Generator[Dict, None, None]:
+        raise NotImplementedError  # pragma: no cover
+
+    @property
+    @abstractmethod
+    def queue(self) -> Any:
+        raise NotImplementedError  # pragma: no cover

--- a/elife_bus_sdk/queues/sqs_queue.py
+++ b/elife_bus_sdk/queues/sqs_queue.py
@@ -1,0 +1,102 @@
+from typing import Dict, Generator, List
+
+try:
+    import boto3
+except ImportError:  # pragma: no cover
+    # boto3 not yet available, may happen in initial install of elife_bus_sdk package
+    pass
+
+from elife_bus_sdk.queues.message_queue import MessageQueue
+
+
+class SQSMessageQueue(MessageQueue):
+    name = 'sqs'
+
+    def __init__(self, **overrides):
+        self._queue_name = overrides.pop('QueueName', None)
+        self._overrides = overrides
+        self._resource = boto3.resource(self.name, **self._overrides)
+        self._queue = self._resource.get_queue_by_name(QueueName=self._queue_name)
+
+    def dequeue(self) -> List['sqs.Message']:
+        """Retrieves one or more messages (up to 10), from the queue.
+
+        :return: list
+        """
+        conf = self._overrides
+        return self._queue.receive_messages(MaxNumberOfMessages=conf.get('MaxNumberOfMessages', 1),
+                                            VisibilityTimeout=conf.get('VisibilityTimeout', 60),
+                                            WaitTimeSeconds=conf.get('WaitTimeSeconds', 20))
+
+    def enqueue(self, message: str) -> Dict[str, str]:
+        """Delivers a message to the queue.
+
+        :param message: str
+        :return: dict
+
+        example return value:
+        {
+            'MD5OfMessageBody': 'string',
+            'MD5OfMessageAttributes': 'string',
+            'MessageId': 'string',
+            'SequenceNumber': 'string'
+        }
+        """
+        return self._queue.send_message(MessageBody=message)
+
+    @staticmethod
+    def parse_message(message: 'sqs.Message') -> Dict[str, str]:
+        """Parse a `sqs.Message` object and return a `dict` representation.
+
+        :param message: :class: sqs.Message
+        :return: dict
+        """
+        return {
+            'body': message.body,
+            'md5_of_body': message.md5_of_body,
+            'message_id': message.message_id,
+            'queue_url': message.queue_url,
+            'receipt_handle': message.receipt_handle
+        }
+
+    def poll(self, parse_msg: bool = True) -> Generator[Dict, None, None]:
+        """An infinite poll on the given queue object.
+
+        Blocks for `WaitTimeSeconds` seconds before connection is dropped and re-established.
+
+        If `parse_msg` is False, then you will be returned the the original `sqs.Message` object.
+
+        :param parse_msg: bool
+        :return: generator
+        """
+        while True:
+            messages = []
+
+            while not messages:
+                messages = self.dequeue()
+
+            if not messages:
+                continue
+
+            message = messages[0]
+
+            try:
+                if parse_msg:
+                    yield self.parse_message(message)
+                else:
+                    yield message
+            except AttributeError:
+                yield {}
+            finally:
+                message.delete()
+
+    @property
+    def queue(self) -> 'sqs.Queue':
+        """Returns the current `sqs.Queue` instance for the class.
+
+        Any additional `boto3.sqs.Queue` functionality can be accessed by using this
+        object directly.
+
+        :return: :class: `sqs.Queue`
+        """
+        return self._queue

--- a/elife_bus_sdk/queues/sqs_queue.py
+++ b/elife_bus_sdk/queues/sqs_queue.py
@@ -13,7 +13,7 @@ class SQSMessageQueue(MessageQueue):
     name = 'sqs'
 
     def __init__(self, **overrides):
-        self._queue_name = overrides.pop('QueueName', None)
+        self._queue_name = overrides.pop('queue_name', None)
         self._overrides = overrides
         self._resource = boto3.resource(self.name, **self._overrides)
         self._queue = self._resource.get_queue_by_name(QueueName=self._queue_name)

--- a/elife_bus_sdk/queues/sqs_queue.py
+++ b/elife_bus_sdk/queues/sqs_queue.py
@@ -8,6 +8,8 @@ from elife_bus_sdk.queues.message_queue import MessageQueue
 
 class SQSMessageQueue(MessageQueue):
     name = 'sqs'
+    _polling = False
+    _stop_polling = False
 
     def __init__(self, **overrides):
         self._queue_name = overrides.pop('queue_name', None)
@@ -15,15 +17,17 @@ class SQSMessageQueue(MessageQueue):
         self._resource = boto3.resource(self.name, **self._overrides)
         self._queue = self._resource.get_queue_by_name(QueueName=self._queue_name)
 
-    def dequeue(self) -> List['sqs.Message']:
+    def dequeue(self) -> List[Event]:
         """Retrieves one or more messages (up to 10), from the queue.
 
         :return: list
         """
         conf = self._overrides
-        return self._queue.receive_messages(MaxNumberOfMessages=conf.get('MaxNumberOfMessages', 1),
+        msgs = self._queue.receive_messages(MaxNumberOfMessages=conf.get('MaxNumberOfMessages', 1),
                                             VisibilityTimeout=conf.get('VisibilityTimeout', 60),
                                             WaitTimeSeconds=conf.get('WaitTimeSeconds', 20))
+
+        return [Event(**self._parse_message(msg)) for msg in msgs]
 
     def enqueue(self, message: str) -> Dict[str, str]:
         """Delivers a message to the queue.
@@ -40,6 +44,13 @@ class SQSMessageQueue(MessageQueue):
         }
         """
         return self._queue.send_message(MessageBody=message)
+
+    def is_polling(self) -> bool:
+        """Return current polling state.
+
+        :return:
+        """
+        return self._polling
 
     @staticmethod
     def _parse_message(message: 'sqs.Message') -> Dict[str, str]:
@@ -63,23 +74,23 @@ class SQSMessageQueue(MessageQueue):
 
         :return: generator
         """
-        while True:
-            messages = []
+        # signal that instance is currently polling
+        self._polling = True
 
-            while not messages:
-                messages = self.dequeue()
+        while not self._stop_polling:
+            messages = self.dequeue()
 
             if not messages:
                 continue
 
-            message = messages[0]
-
             try:
-                yield Event(**self._parse_message(message))
-            except AttributeError:
-                yield None
-            finally:
-                message.delete()
+                yield messages[0]
+            except (AttributeError, IndexError):
+                yield Event()
+
+        # finished, reset polling flag(s) for next poll call
+        self._stop_polling = False
+        self._polling = False
 
     @property
     def queue(self) -> 'sqs.Queue':
@@ -91,3 +102,10 @@ class SQSMessageQueue(MessageQueue):
         :return: :class: `sqs.Queue`
         """
         return self._queue
+
+    def stop_polling(self) -> None:
+        """Set `_stop_polling` flag to True signalling an active poll call to exit.
+
+        :return:
+        """
+        self._stop_polling = True

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -21,6 +21,13 @@ def invalid_config() -> Dict[str, str]:
 
 
 @fixture
+def mock_sqs_queue(sqs_message: NamedTuple) -> MagicMock:
+    mock_queue = MagicMock()
+    mock_queue.receive_messages.return_value = [sqs_message]
+    return mock_queue
+
+
+@fixture
 def sqs_message() -> NamedTuple:
     fields = ['body',
               'md5_of_body',
@@ -50,7 +57,9 @@ def sns_publisher(mock_boto: MagicMock, dev_config_overrides: Dict[str, str],
 @fixture
 @patch('elife_bus_sdk.queues.sqs_queue.boto3')
 # pylint:disable=unused-argument
-def sqs_message_queue(mock_boto: MagicMock, valid_sqs_config: Dict[str, str]):
+def sqs_message_queue(mock_boto: MagicMock, mock_sqs_queue,
+                      valid_sqs_config: Dict[str, str]):
+    mock_boto.resource.return_value.get_queue_by_name.return_value = mock_sqs_queue
     return SQSMessageQueue(**valid_sqs_config)
 
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -67,5 +67,5 @@ def valid_config() -> Dict[str, str]:
 @fixture
 def valid_sqs_config() -> Dict[str, str]:
     return {
-        'QueueName': 'test7',
+        'queue_name': 'test7',
     }

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,23 +1,71 @@
+from collections import namedtuple
+from unittest.mock import patch, MagicMock
+from typing import Dict, NamedTuple
+
 from pytest import fixture
+
+from elife_bus_sdk.publishers import SNSPublisher
+from elife_bus_sdk.queues import SQSMessageQueue
 
 
 @fixture
-def dev_config_overrides():
+def dev_config_overrides() -> Dict[str, str]:
     return {
         'endpoint_url': 'http://0.0.0.0:4100'
     }
 
 
 @fixture
-def invalid_config():
+def invalid_config() -> Dict[str, str]:
     return {'invalid': 'config'}
 
 
 @fixture
-def valid_config():
+def sqs_message() -> NamedTuple:
+    fields = ['body',
+              'md5_of_body',
+              'message_id',
+              'queue_url',
+              'receipt_handle']
+
+    message = namedtuple('Message', fields)
+
+    return message(
+        body='body',
+        md5_of_body='md5 body',
+        message_id='0000000',
+        queue_url='some url',
+        receipt_handle='111111',
+    )
+
+
+@fixture
+@patch('elife_bus_sdk.publishers.sns_publisher.boto3')
+# pylint:disable=unused-argument
+def sns_publisher(mock_boto: MagicMock, dev_config_overrides: Dict[str, str],
+                  valid_config: Dict[str, str]):
+    return SNSPublisher(**valid_config, **dev_config_overrides)
+
+
+@fixture
+@patch('elife_bus_sdk.queues.sqs_queue.boto3')
+# pylint:disable=unused-argument
+def sqs_message_queue(mock_boto: MagicMock, valid_sqs_config: Dict[str, str]):
+    return SQSMessageQueue(**valid_sqs_config)
+
+
+@fixture
+def valid_config() -> Dict[str, str]:
     return {
         'region': 'local',
         'subscriber': '00000000000',
         'name': 'test-topic',
         'env': 'dev'
+    }
+
+
+@fixture
+def valid_sqs_config() -> Dict[str, str]:
+    return {
+        'QueueName': 'test7',
     }

--- a/test/test_event_publisher.py
+++ b/test/test_event_publisher.py
@@ -1,23 +1,21 @@
-from unittest.mock import patch
+from typing import Dict
+from unittest.mock import patch, MagicMock
 
 from elife_bus_sdk import get_publisher
 from elife_bus_sdk.publishers import SNSPublisher
 
 
 @patch('elife_bus_sdk.publishers.sns_publisher.boto3')
-def test_it_will_receive_default_name_if_name_is_not_supplied(valid_config):
-    publisher = get_publisher(pub_type='sns', config=valid_config)
-    publisher2 = get_publisher(pub_name='default_publisher', config=valid_config)
-    assert publisher is publisher2
-
-
-@patch('elife_bus_sdk.publishers.sns_publisher.boto3')
-def test_it_will_receive_default_type_if_type_is_not_supplied(valid_config):
-    publisher = get_publisher(pub_name='test1', config=valid_config)
+# pylint:disable=unused-argument
+def test_it_will_receive_default_type_if_type_is_not_supplied(mock_boto: MagicMock,
+                                                              valid_config: Dict[str, str]):
+    publisher = get_publisher(config=valid_config)
     assert isinstance(publisher, SNSPublisher)
 
 
 @patch('elife_bus_sdk.publishers.sns_publisher.boto3')
-def test_it_returns_publisher_instance_when_given_valid_type(valid_config):
-    publisher = get_publisher(pub_name='test1', pub_type='sns', config=valid_config)
+# pylint:disable=unused-argument
+def test_it_returns_publisher_instance_when_given_valid_type(mock_boto: MagicMock,
+                                                             valid_config: Dict[str, str]):
+    publisher = get_publisher(pub_type='sns', config=valid_config)
     assert isinstance(publisher, SNSPublisher)

--- a/test/test_publishers.py
+++ b/test/test_publishers.py
@@ -1,12 +1,13 @@
 import pytest
 
 from elife_bus_sdk import get_publisher
+from elife_bus_sdk.exceptions import PublisherTypeNotFound
 from elife_bus_sdk.publishers import get_publisher_types, SNSPublisher
 
 
 def test_it_raises_exception_for_unitialized_publisher_type():
-    with pytest.raises(AttributeError):
-        get_publisher(pub_name='some_invalid_name', pub_type='', config={})
+    with pytest.raises(PublisherTypeNotFound):
+        get_publisher(pub_type='', config={})
 
 
 def test_it_will_have_valid_publisher_types_on_init():

--- a/test/test_queues.py
+++ b/test/test_queues.py
@@ -1,0 +1,29 @@
+from unittest.mock import patch, MagicMock
+from typing import Dict
+
+import pytest
+
+from elife_bus_sdk import get_queue
+from elife_bus_sdk.exceptions import MessageQueueTypeNotFound
+from elife_bus_sdk.queues import get_queue_types, SQSMessageQueue
+
+
+@patch('elife_bus_sdk.queues.sqs_queue.boto3')
+# pylint:disable=unused-argument
+def test_can_get_queue(mock_boto: MagicMock, valid_sqs_config: Dict[str, str]):
+    assert get_queue(q_type='sqs', config=valid_sqs_config)
+
+
+def test_it_raises_exception_for_unitialized_queue_type():
+    with pytest.raises(MessageQueueTypeNotFound):
+        get_queue(q_type='', config={})
+
+
+def test_it_will_have_valid_queue_types_on_init():
+    assert len(get_queue_types()) == 1
+
+
+def test_children_of_message_queue_get_registered_by_name():
+    queue_types = get_queue_types()
+
+    assert queue_types['sqs'] == SQSMessageQueue

--- a/test/test_sns_publisher.py
+++ b/test/test_sns_publisher.py
@@ -1,37 +1,25 @@
-from unittest.mock import patch
-
 import pytest
 
 from elife_bus_sdk.events import ProfileEvent
 from elife_bus_sdk.publishers import SNSPublisher
 
 
-@patch('elife_bus_sdk.publishers.sns_publisher.boto3')
-def test_it_will_create_arn_with_if_config_is_valid(dev_config_overrides, valid_config):
-    publisher = SNSPublisher(**valid_config, **dev_config_overrides)
-    assert publisher.arn == 'arn:aws:sns:local:00000000000:test-topic--dev'
+def test_it_will_create_arn_with_if_config_is_valid(sns_publisher: SNSPublisher):
+    assert sns_publisher.arn == 'arn:aws:sns:local:00000000000:test-topic--dev'
 
 
-@patch('elife_bus_sdk.publishers.sns_publisher.boto3')
-def test_it_will_fail_to_publish_an_invalid_event(dev_config_overrides, valid_config):
+def test_it_will_fail_to_publish_an_invalid_event(sns_publisher: SNSPublisher):
     event = {'invlaid': 'data'}
-    publisher = SNSPublisher(**valid_config, **dev_config_overrides)
     with pytest.raises(AttributeError):
-        publisher.publish(event=event)
+        sns_publisher.publish(event=event)
 
 
-@patch('elife_bus_sdk.publishers.sns_publisher.boto3')
-def test_it_will_publish_a_valid_event(mock_boto, dev_config_overrides, valid_config):
-    mock_boto.resource.Topic.publish.return_value = {}
-
+def test_it_will_publish_a_valid_event(sns_publisher: SNSPublisher):
     event = ProfileEvent(id='12345')
-    publisher = SNSPublisher(**valid_config, **dev_config_overrides)
-    assert publisher.publish(event=event)
+    assert sns_publisher.publish(event=event)
 
 
-@patch('elife_bus_sdk.publishers.sns_publisher.boto3')
-def test_it_will_raise_error_if_passed_invalid_event_type(dev_config_overrides, valid_config):
+def test_it_will_raise_error_if_passed_invalid_event_type(sns_publisher: SNSPublisher):
     event = 'invalid_type'
-    publisher = SNSPublisher(**valid_config, **dev_config_overrides)
     with pytest.raises(AttributeError):
-        publisher.publish(event=event)
+        sns_publisher.publish(event=event)

--- a/test/test_sqs_queue.py
+++ b/test/test_sqs_queue.py
@@ -1,3 +1,6 @@
+import time
+import threading
+
 from elife_bus_sdk.queues import SQSMessageQueue
 
 
@@ -9,9 +12,28 @@ def test_can_send_message(sqs_message_queue: SQSMessageQueue):
     assert sqs_message_queue.enqueue('test')
 
 
-def test_can_receive_message(sqs_message_queue: SQSMessageQueue):
-    assert sqs_message_queue.dequeue()
+def test_can_call_dequeue(sqs_message_queue: SQSMessageQueue):
+    assert sqs_message_queue.dequeue() == []
 
 
-def test_can_poll_for_messages(sqs_message_queue: SQSMessageQueue):
-    assert next(sqs_message_queue.poll())
+def test_can_check_polling_state(sqs_message_queue: SQSMessageQueue):
+    assert not sqs_message_queue.is_polling()
+
+
+def test_can_start_and_polling(sqs_message_queue: SQSMessageQueue):
+    def poll_wrapper():
+        try:
+            next(sqs_message_queue.poll())
+        except StopIteration:
+            pass
+
+    poll_thread = threading.Thread(target=poll_wrapper)
+    poll_thread.start()
+
+    assert sqs_message_queue.is_polling()
+
+    time.sleep(1)
+    sqs_message_queue.stop_polling()
+    poll_thread.join()
+
+    assert not sqs_message_queue.is_polling()

--- a/test/test_sqs_queue.py
+++ b/test/test_sqs_queue.py
@@ -1,15 +1,8 @@
-from typing import NamedTuple
-
 from elife_bus_sdk.queues import SQSMessageQueue
 
 
 def test_can_get_queue(sqs_message_queue: SQSMessageQueue):
     assert sqs_message_queue.queue
-
-
-def test_can_parse_message(sqs_message: NamedTuple,
-                           sqs_message_queue: SQSMessageQueue):
-    assert sqs_message_queue.parse_message(sqs_message)
 
 
 def test_can_send_message(sqs_message_queue: SQSMessageQueue):

--- a/test/test_sqs_queue.py
+++ b/test/test_sqs_queue.py
@@ -1,5 +1,6 @@
 import time
 import threading
+from typing import NamedTuple
 
 from elife_bus_sdk.queues import SQSMessageQueue
 
@@ -8,12 +9,20 @@ def test_can_get_queue(sqs_message_queue: SQSMessageQueue):
     assert sqs_message_queue.queue
 
 
-def test_can_send_message(sqs_message_queue: SQSMessageQueue):
-    assert sqs_message_queue.enqueue('test')
+def test_can_send_message(sqs_message: NamedTuple, sqs_message_queue: SQSMessageQueue):
+    assert sqs_message_queue.enqueue(sqs_message)
 
 
 def test_can_call_dequeue(sqs_message_queue: SQSMessageQueue):
-    assert sqs_message_queue.dequeue() == []
+    message = sqs_message_queue.dequeue()[0]
+    assert message == {
+        'body': 'body',
+        'md5_of_body': 'md5 body',
+        'message_id': '0000000',
+        'queue_url': 'some url',
+        'receipt_handle': '111111',
+        'type': 'base_msg'
+    }
 
 
 def test_can_check_polling_state(sqs_message_queue: SQSMessageQueue):
@@ -23,7 +32,8 @@ def test_can_check_polling_state(sqs_message_queue: SQSMessageQueue):
 def test_can_start_and_polling(sqs_message_queue: SQSMessageQueue):
     def poll_wrapper():
         try:
-            next(sqs_message_queue.poll())
+            while True:
+                next(sqs_message_queue.poll())
         except StopIteration:
             pass
 

--- a/test/test_sqs_queue.py
+++ b/test/test_sqs_queue.py
@@ -1,0 +1,24 @@
+from typing import NamedTuple
+
+from elife_bus_sdk.queues import SQSMessageQueue
+
+
+def test_can_get_queue(sqs_message_queue: SQSMessageQueue):
+    assert sqs_message_queue.queue
+
+
+def test_can_parse_message(sqs_message: NamedTuple,
+                           sqs_message_queue: SQSMessageQueue):
+    assert sqs_message_queue.parse_message(sqs_message)
+
+
+def test_can_send_message(sqs_message_queue: SQSMessageQueue):
+    assert sqs_message_queue.enqueue('test')
+
+
+def test_can_receive_message(sqs_message_queue: SQSMessageQueue):
+    assert sqs_message_queue.dequeue()
+
+
+def test_can_poll_for_messages(sqs_message_queue: SQSMessageQueue):
+    assert next(sqs_message_queue.poll())


### PR DESCRIPTION
- Added SQS queue functionality.
- No longer allow publisher instances to be stored and given friendly names, you get returned it on init and that's that.

Hopefully, the [README.md](https://github.com/elifesciences/bus-sdk-python/compare/feature_sqs_queues?expand=1#diff-04c6e90faac2675aa89e2176d2eec7d8) explains all required usage scenarios. 
